### PR TITLE
Fixed axios require in the pkgcontrol package

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ var packageTemplate = require("./templates/package.html");
 
 var Q = codebox.require("q");
 var _ = codebox.require("hr.utils");
-var axios = require("axios");
+var axios = codebox.require("axios");
 var commands = codebox.require("core/commands");
 var dialogs = codebox.require("utils/dialogs");
 var packages = codebox.require("core/packages");


### PR DESCRIPTION
Fixes error:
Cannot find module 'axios' from '.nvm/v0.10.38/lib/node_modules/codebox/packages/pkgcontrol/src'
